### PR TITLE
support specifying secret per client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,16 @@ func (p radiusService) RadiusHandle(request *radius.Packet) *radius.Packet {
 }
 
 func main() {
-	s := radius.NewServer(":1812", "sEcReT", radiusService{})
+	s := radius.NewServer(":1812", "secret", radiusService{})
+
+	// or you can convert it to a server that accept request 
+	// from some host with different secret
+	// cls := radius.NewClientList([]radius.Client{
+	// 		radius.NewClient("127.0.0.1", "secret1"),
+	// 		radius.NewClient("10.10.10.10", "secret2"),
+	// })
+	// s.WithClientList(cls)
+
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	errChan := make(chan error)

--- a/client.go
+++ b/client.go
@@ -1,0 +1,90 @@
+package radius
+
+import "sync"
+
+func NewClientList(cs []Client) *ClientList {
+	cl := new(ClientList)
+	cl.SetHerd(cs)
+	return cl
+}
+
+// ClientList are list of client allowed to communicate with server
+type ClientList struct {
+	herd map[string]Client
+	sync.RWMutex
+}
+
+// Get client from list of clients based on host
+func (cls *ClientList) Get(host string) Client {
+	cls.RLock()
+	defer cls.RUnlock()
+	cl, _ := cls.herd[host]
+	return cl
+}
+
+// Add new client or reset existing client based on host
+func (cls *ClientList) AddOrUpdate(cl Client) {
+	cls.Lock()
+	defer cls.Unlock()
+	cls.herd[cl.GetHost()] = cl
+}
+
+// Remove client based on host
+func (cls *ClientList) Remove(host string) {
+	cls.Lock()
+	defer cls.Unlock()
+	delete(cls.herd, host)
+}
+
+// SetHerd reset/initialize the herd of clients
+func (cls *ClientList) SetHerd(herd []Client) {
+	cls.Lock()
+	defer cls.Unlock()
+	if cls.herd == nil {
+		cls.herd = make(map[string]Client)
+	}
+	for _, v := range herd {
+		cls.herd[v.GetHost()] = v
+	}
+}
+
+func (cls *ClientList) GetHerd() []Client {
+	cls.RLock()
+	defer cls.RUnlock()
+	herd := make([]Client, len(cls.herd))
+	i := 0
+	for _, v := range cls.herd {
+		herd[i] = v
+		i++
+	}
+	return herd
+}
+
+// Client represent a client to connect to radius server
+type Client interface {
+	// GetHost get the client host
+	GetHost() string
+	// GetSecret get shared secret
+	GetSecret() string
+}
+
+// NewClient return new client
+func NewClient(host, secret string) Client {
+	return &DefaultClient{host, secret}
+}
+
+// DefaultClient is default client implementation
+type DefaultClient struct {
+	Host   string
+	Secret string
+}
+
+// GetSecret get shared secret
+func (cl *DefaultClient) GetSecret() string {
+	return cl.Secret
+}
+
+// GetHost get the client host
+func (cl *DefaultClient) GetHost() string {
+	return cl.Host
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,31 @@
+package radius
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestClientList(t *testing.T) {
+	herd := []Client{
+		NewClient("1.1.1.1", "secret1"),
+		NewClient("2.2.2.2", "secret2"),
+	}
+	cls := NewClientList(herd)
+
+	ok(reflect.DeepEqual(cls.GetHerd(), herd))
+
+	newClient := NewClient("3.3.3.3", "secret3")
+	cls.AddOrUpdate(newClient)
+	ok(reflect.DeepEqual(cls.Get("3.3.3.3"), newClient))
+	ok(len(cls.GetHerd()) == 3)
+
+	updateClient := NewClient("1.1.1.1", "updatesecret")
+	cls.AddOrUpdate(updateClient)
+	ok(reflect.DeepEqual(cls.Get("1.1.1.1"), updateClient))
+	ok(len(cls.GetHerd()) == 3)
+
+	cls.Remove("3.3.3.3")
+	println(cls.Get("3.3.3.3"))
+	ok(cls.Get("3.3.3.3") == nil)
+	ok(len(cls.GetHerd()) == 2)
+}


### PR DESCRIPTION
Hi, I add support for multiple secrets based on client host so that radius only process request from known host. It's optional, you can still use the global one if you want to. 
