### PR TITLE
Fixed accounting input/output counts

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -323,7 +323,7 @@ func (p *Packet) GetAcctTotalOutputOctets() uint64 {
 	}
 	avp = p.GetAVP(AcctOutputGigawords)
 	if avp != nil {
-		out += uint64(avp.Decode(p).(uint32))*2 ^ 32
+		out += uint64(avp.Decode(p).(uint32)) << 32
 	}
 	return out
 }
@@ -336,7 +336,7 @@ func (p *Packet) GetAcctTotalInputOctets() uint64 {
 	}
 	avp = p.GetAVP(AcctInputGigawords)
 	if avp != nil {
-		out += uint64(avp.Decode(p).(uint32))*2 ^ 32
+		out += uint64(avp.Decode(p).(uint32)) << 32
 	}
 	return out
 }


### PR DESCRIPTION
Calculations were trying to bitshift by 32 bits by multiplying by 2 ^ 32.
Since ^ is a bitwise XOR operator, this did not have the intended effect.
Switched to bitshift operator.
