### PR TITLE
Check length of packet buffer

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -185,6 +185,9 @@ func (p *Packet) Send(c net.PacketConn, addr net.Addr) error {
 }
 
 func DecodePacket(Secret string, buf []byte) (p *Packet, err error) {
+	if len(buf) < 20 {
+		return nil, errors.New("invalid length")
+	}
 	p = &Packet{Secret: Secret}
 	p.Code = PacketCode(buf[0])
 	p.Identifier = buf[1]


### PR DESCRIPTION
Checking length of packet buffer to prevent panic from slice bounds out of range if packet length is less than 20.

If you send a short test packet with PacketSender you can observe the panic this pull request fixes. Checking for a length over 20 prevents the panic. 